### PR TITLE
Added xorriso-hack to make isos > 4gb possible

### DIFF
--- a/xorriso-hack.sh
+++ b/xorriso-hack.sh
@@ -1,0 +1,5 @@
+if test $# -eq 2; then
+    xorriso "$@"
+else
+    xorriso "$@" -iso-level 3 
+fi


### PR DESCRIPTION
I added this "hack" to set the iso-level to 3. 

This enables isos bigger than 4gb (up to 400 i think). 

grub-mkrescue has to be activated with 

`grub-mkrescue xorriso=./xorriso-hack.sh ...`

Cheers,

Wolf